### PR TITLE
Feature/share

### DIFF
--- a/app/src/main/java/org/sopt/havit/util/BindingAdapter.kt
+++ b/app/src/main/java/org/sopt/havit/util/BindingAdapter.kt
@@ -36,7 +36,6 @@ object BindingAdapter {
     fun ImageView.loadIcon(url: Int?) {
         Glide.with(context)
             .load(url)
-            .circleCrop()
             .into(this)
     }
 

--- a/app/src/main/res/layout/activity_category_content_modify.xml
+++ b/app/src/main/res/layout/activity_category_content_modify.xml
@@ -104,9 +104,8 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_icon"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="20dp"
             android:layout_marginTop="17dp"
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:layout_constraintEnd_toEndOf="parent"
@@ -114,9 +113,7 @@
             app:layout_constraintTop_toBottomOf="@+id/tv_ic"
             app:spanCount="5"
             tools:itemCount="15"
-            tools:listitem="@layout/item_category_icon">
-        </androidx.recyclerview.widget.RecyclerView>
-
+            tools:listitem="@layout/item_category_icon"/>
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_remove"

--- a/app/src/main/res/layout/fragment_category_icon.xml
+++ b/app/src/main/res/layout/fragment_category_icon.xml
@@ -82,9 +82,8 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_icon"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="20dp"
             android:layout_marginTop="16dp"
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_choose_icon.xml
+++ b/app/src/main/res/layout/fragment_choose_icon.xml
@@ -87,7 +87,7 @@
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_icon"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="20dp"
                 android:layout_marginTop="16dp"
@@ -97,11 +97,7 @@
                 app:layout_constraintTop_toBottomOf="@id/tv_title"
                 app:spanCount="5"
                 tools:itemCount="15"
-                tools:listitem="@layout/item_category_icon">
-
-
-            </androidx.recyclerview.widget.RecyclerView>
-
+                tools:listitem="@layout/item_category_icon"/>
 
             <Button
                 android:id="@+id/btn_next"

--- a/app/src/main/res/layout/item_category_icon.xml
+++ b/app/src/main/res/layout/item_category_icon.xml
@@ -13,6 +13,8 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/cl_icon"
         android:layout_width="59dp"
+        android:layout_marginStart="3dp"
+        android:layout_marginEnd="3dp"
         android:layout_height="59dp"
         android:layout_marginBottom="6dp"
         android:background="@drawable/oval_gray">

--- a/app/src/main/res/layout/item_category_icon.xml
+++ b/app/src/main/res/layout/item_category_icon.xml
@@ -17,7 +17,7 @@
         android:layout_marginBottom="6dp"
         android:background="@drawable/oval_gray">
 
-        <de.hdodenhof.circleimageview.CircleImageView
+        <ImageView
             android:id="@+id/iv_icon"
             localIcon="@{categoryIcon}"
             android:layout_width="44dp"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59546818/154331512-00a15667-0f81-4fb8-8b6a-dc9a91175891.png)

위의 뷰에서 발생하는 2가지 오류를 해결
1. 아이콘 꼭지점 잘림 현상 해결 (CircleCrop -> ImageView 사용)
    - closed #304 

<br/>

2. GridLayout과 그 안에 들어가는 item의 margin값 조정을 통해 가운데 정렬
    - closed #305 