### PR TITLE
[FIX] 실수로 삭제한 코드 as () -> Unit 다시 넣기

### DIFF
--- a/app/src/main/java/org/sopt/havit/ui/contents/more/ContentsMoreFragment.kt
+++ b/app/src/main/java/org/sopt/havit/ui/contents/more/ContentsMoreFragment.kt
@@ -75,8 +75,8 @@ class ContentsMoreFragment : BottomSheetDialogFragment() {
     // 이전 뷰에서 bundle로 보낸 content 데이터 받아오기
     private fun setData() {
         contentsData = arguments?.getParcelable(CONTENTS_MORE_DATA) ?: throw IllegalStateException()
-        showDeleteDialog = arguments?.getSerializable(SHOW_DELETE_DIALOG)
-        refreshData = arguments?.getSerializable(REFRESH_DATA)
+        showDeleteDialog = arguments?.getSerializable(SHOW_DELETE_DIALOG) as () -> Unit
+        refreshData = arguments?.getSerializable(REFRESH_DATA) as () -> Unit
         arguments?.getInt(POSITION, 0)?.let {
             pos = it
         }


### PR DESCRIPTION
실수로 `as () -> Unit`을 삭제해버렸나봐요..... 급하게 다시 넣어서 올립니당