### PR TITLE
[FIX] HomeFragment / 뷰 재진입 시 StickyHeader Y Position 위치 오류 (#752)

### DIFF
--- a/app/src/main/java/org/sopt/havit/util/StickyScrollView.kt
+++ b/app/src/main/java/org/sopt/havit/util/StickyScrollView.kt
@@ -45,6 +45,8 @@ class StickyScrollView : NestedScrollView, ViewTreeObserver.OnGlobalLayoutListen
     override fun onScrollChanged(l: Int, t: Int, oldl: Int, oldt: Int) {
         super.onScrollChanged(l, t, oldl, oldt)
 
+        if (mHeaderInitPosition == 0f) mHeaderInitPosition = header?.top?.toFloat() ?: return
+
         if (t > mHeaderInitPosition) {
             stickHeader(t - mHeaderInitPosition)
         } else {


### PR DESCRIPTION
- closed #752 
자세한 내용은 이슈참고!