### PR TITLE
[FIX] 최근저장 콘텐츠 -> 카테고리 width adjust 버그 수정 (#779)

### DIFF
--- a/app/src/main/res/layout/item_home_recent_contents_list.xml
+++ b/app/src/main/res/layout/item_home_recent_contents_list.xml
@@ -39,12 +39,14 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:background="@drawable/rectangle_purple_1_radius_4"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/cv_thumbnail">
 
             <TextView
                 android:id="@+id/tv_title"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="6dp"
                 android:layout_marginVertical="4dp"


### PR DESCRIPTION
- closed #779 
<img width="300" src="https://user-images.githubusercontent.com/59546818/200529444-e2b7cfbe-514a-49e1-9220-b8d8b478ca41.png">
