### PR TITLE
[FIX] 닉네임 생성시 띄어쓰기 되지 않도록 설정 (#842)

### DIFF
--- a/app/src/main/java/org/sopt/havit/ui/sign/AddNickNameFragment.kt
+++ b/app/src/main/java/org/sopt/havit/ui/sign/AddNickNameFragment.kt
@@ -42,15 +42,21 @@ class AddNickNameFragment :
 
     private fun setTextWatcher() {
         binding.etNickname.addTextChangedListener {
-            signUpViewModel.setNickName(
-                binding.etNickname.text.toString().replace("\\s".toRegex(), "")
-            )
+            val hasSpace = binding.etNickname.text?.toString()?.contains("\\s".toRegex()) ?: false
+            if (hasSpace) { // 닉네임에 띄어쓰기 포함
+                signUpViewModel.nickNameStatus.value = NickNameTextStatus.HAS_SPACING
+            } else if (binding.etNickname.text?.toString()?.isEmpty() == true) { // 닉네임이 공백일 때
+                signUpViewModel.nickNameStatus.value = NickNameTextStatus.EMPTY
+            } else { // 정상 닉네임 입력할 때
+                signUpViewModel.nickNameStatus.value = NickNameTextStatus.FILLED
+            }
             binding.etNickname.setSelection(binding.etNickname.length())
         }
     }
 
     private fun setListener() {
         binding.btnNicknameNext.setOnClickListener {
+            signUpViewModel.setNickName(binding.etNickname.text.toString())
             signUpViewModel.setMoveToNextOrBack(true)
         }
         binding.ivNicknameDeleteText.setOnClickListener {

--- a/app/src/main/java/org/sopt/havit/ui/sign/AddNickNameFragment.kt
+++ b/app/src/main/java/org/sopt/havit/ui/sign/AddNickNameFragment.kt
@@ -42,7 +42,10 @@ class AddNickNameFragment :
 
     private fun setTextWatcher() {
         binding.etNickname.addTextChangedListener {
-            signUpViewModel.setNickName(binding.etNickname.text.toString())
+            signUpViewModel.setNickName(
+                binding.etNickname.text.toString().replace("\\s".toRegex(), "")
+            )
+            binding.etNickname.setSelection(binding.etNickname.length())
         }
     }
 

--- a/app/src/main/java/org/sopt/havit/ui/sign/NickNameTextStatus.kt
+++ b/app/src/main/java/org/sopt/havit/ui/sign/NickNameTextStatus.kt
@@ -1,0 +1,5 @@
+package org.sopt.havit.ui.sign
+
+enum class NickNameTextStatus {
+    EMPTY, HAS_SPACING, FILLED
+}

--- a/app/src/main/java/org/sopt/havit/ui/sign/SignUpViewModel.kt
+++ b/app/src/main/java/org/sopt/havit/ui/sign/SignUpViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import android.view.View
 import androidx.lifecycle.*
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import org.sopt.havit.R
 import org.sopt.havit.domain.entity.NetworkState
@@ -22,6 +23,8 @@ class SignUpViewModel @Inject constructor(
     var isServerNetwork = MutableLiveData<NetworkState>()
 
     var nickName = MutableLiveData(authRepository.getUserNickName())
+
+    val nickNameStatus = MutableStateFlow(NickNameTextStatus.EMPTY)
 
     private var _fcmToken = MutableLiveData<String>()
 
@@ -122,6 +125,7 @@ class SignUpViewModel @Inject constructor(
 
     fun setClearNickName() {
         nickName.value = ""
+        nickNameStatus.value = NickNameTextStatus.EMPTY
     }
 
     fun setMoveToNextOrBack(move: Boolean) {

--- a/app/src/main/res/layout/fragment_add_nick_name.xml
+++ b/app/src/main/res/layout/fragment_add_nick_name.xml
@@ -5,6 +5,12 @@
 
     <data>
 
+        <import type="android.view.View" />
+
+        <variable
+            name="status"
+            type="org.sopt.havit.ui.sign.NickNameTextStatus" />
+
         <variable
             name="vm"
             type="org.sopt.havit.ui.sign.SignUpViewModel" />
@@ -78,6 +84,39 @@
             app:layout_constraintStart_toStartOf="@+id/et_nickname"
             app:layout_constraintTop_toBottomOf="@+id/et_nickname" />
 
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_notice"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:visibility="@{vm.nickNameStatus == status.HAS_SPACING ? View.VISIBLE : View.INVISIBLE}"
+            app:layout_constraintStart_toStartOf="@id/view"
+            app:layout_constraintTop_toBottomOf="@id/view">
+
+
+            <ImageView
+                android:id="@+id/iv_notice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="2dp"
+                android:src="@drawable/ic_notice_red"
+                app:layout_constraintBottom_toBottomOf="@id/cl_notice"
+                app:layout_constraintStart_toStartOf="@id/cl_notice"
+                app:layout_constraintTop_toTopOf="@id/cl_notice" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:text="@string/notice_nickname_spacing"
+                android:textAppearance="@style/Sub12Regular"
+                android:textColor="@color/havit_red"
+                app:layout_constraintBottom_toBottomOf="@id/iv_notice"
+                app:layout_constraintStart_toEndOf="@id/iv_notice"
+
+                app:layout_constraintTop_toTopOf="@id/iv_notice" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
         <TextView
             android:id="@+id/tv_category_length_limit"
             android:layout_width="wrap_content"
@@ -115,10 +154,10 @@
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_nickname_next"
-            btnColor="@{vm.nickName.empty ? false : true}"
-            android:clickable="@{vm.nickName.empty ? false : true}"
+            btnColor="@{vm.nickNameStatus == status.FILLED ? true : false}"
             android:layout_width="0dp"
             android:layout_height="58dp"
+            android:clickable="@{vm.nickNameStatus == status.FILLED ? true : false}"
             android:text="@string/next"
             android:textAppearance="@style/Text16Semibold"
             android:textColor="@color/white"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -278,4 +278,5 @@
     <string name="service_preparing">서비스 준비중입니다</string>
     <string name="cannot_send_mail">메일을 전송할 수 없습니다</string>
     <string name="error_occurred">문제 발생</string>
+    <string name="notice_nickname_spacing">닉네임에 띄어쓰기는 사용할 수 없습니다.</string>
 </resources>


### PR DESCRIPTION
- 띄어쓰기 입력시 경고 텍스트 보이고 완료 버튼 비활성화 
- 이전에는 공백 입력자체를 막았는데 현재 버전은 공백 입력은 막지 않고 입력시 경고 텍스트와 버튼이 비활성화 됨! 
- 닉네임 입력 상태를 ( 빈 값, 공백 포함, 정상) 으로 구분함