### PR TITLE
[FEAT] release 앱에서 Log 제거

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -24,3 +24,12 @@
 -keep class * extends com.google.gson.TypeAdapter
 -keep class org.sopt.havit.data.remote.** { *; }
 -keep class org.sopt.havit.domain.entity.** { *; }
+
+-assumenosideeffects class android.util.Log {
+    public static boolean isLoggable(java.lang.String, int);
+    public static int v(...);
+    public static int d(...);
+    public static int i(...);
+    public static int w(...);
+    public static int e(...);
+}

--- a/app/src/main/java/org/sopt/havit/data/RetrofitObject.kt
+++ b/app/src/main/java/org/sopt/havit/data/RetrofitObject.kt
@@ -21,8 +21,11 @@ object RetrofitObject {
         readTimeout(20, TimeUnit.SECONDS)
         connectTimeout(20, TimeUnit.SECONDS)
         writeTimeout(5, TimeUnit.SECONDS)
-        addInterceptor(getLoggingInterceptor())
         addInterceptor(getTokenInterceptor(jwt))
+
+        if (DEBUG) {
+            addInterceptor(getLoggingInterceptor())
+        }
     }.build()
 
     private fun getTokenInterceptor(jwt: String) = Interceptor {

--- a/app/src/main/java/org/sopt/havit/di/RetrofitModule.kt
+++ b/app/src/main/java/org/sopt/havit/di/RetrofitModule.kt
@@ -38,15 +38,18 @@ object RetrofitModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpInterceptor(
+    fun provideOkHttpClient(
         interceptor: Interceptor
     ): OkHttpClient {
-        return OkHttpClient.Builder()
-            .addInterceptor(
-                HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BODY }
-            )
-            .addInterceptor(interceptor)
-            .build()
+        return OkHttpClient.Builder().apply {
+            addInterceptor(interceptor)
+
+            if (DEBUG) {
+                addInterceptor(HttpLoggingInterceptor().apply {
+                    level = HttpLoggingInterceptor.Level.BODY
+                })
+            }
+        }.build()
     }
 
     @Provides


### PR DESCRIPTION
- closed #870 

1. 프로가드로 log 지우기
```
-assumenosideeffects class android.util.Log {
    public static boolean isLoggable(java.lang.String, int);
    public static int v(...);
    public static int d(...);
    public static int i(...);
    public static int w(...);
    public static int e(...);
}
```
`-assumenosideeffects` 옵션으로 Log 코드를 release앱에서 지워질 수 있도록 했습니다.
[참고 url](http://sunphiz.me/wp/archives/3779)
[공식문서](https://developer.android.com/topic/security/risks/log-info-disclosure?hl=ko#strip_logs_to_logcat_from_production_builds_by_using_r8)

2. okhttp의 로그 지우기
해당 로그를 프로가드로 지우는 법은 검색했을 때 찾기 힘들어서, debug모드일 때만 `HttpLoggingInterceptor`를 추가했습니다.
* 현재 코드 상 di랑 RetrofitObject를 둘 다 사용하는 곳이 있어서 둘 다에 코드 적용 해뒀습니다. 나중에 RetrofitObject를 사용하는 곳을 리팩토링하면서 di로 대체하기 전까지 해당 코드 적용될 수 있게 하려고 RetrofitObject에도 작성해뒀습니다!