### PR TITLE
[FEAT] Android 33 POST_NOTIFICATIONS 알림권한요청 팝업 구현 (#894)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="org.sopt.havit">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <queries>
         <package android:name="com.kakao.talk" />

--- a/app/src/main/java/org/sopt/havit/ui/sign/SplashWithSignActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/sign/SplashWithSignActivity.kt
@@ -1,14 +1,20 @@
 package org.sopt.havit.ui.sign
 
+import android.Manifest
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.havit.MainActivity
 import org.sopt.havit.R
@@ -37,6 +43,8 @@ class SplashWithSignActivity :
 
     private val signInViewModel: SignInViewModel by viewModels()
     private var isFromShare by Delegates.notNull<Boolean>()
+
+    private val REQUEST_PERMISSION_CODE = 0
 
     private val alphaLogoAnim by lazy {
         AnimationUtils.loadAnimation(this, R.anim.alpha_15_to_5_20000).apply {
@@ -107,7 +115,7 @@ class SplashWithSignActivity :
                 override fun onAnimationRepeat(p0: Animation?) {}
 
                 override fun onAnimationEnd(p0: Animation?) {
-                    setAutoLogin()
+                    checkAlarmPermission()
                 }
             })
         } else {
@@ -161,6 +169,46 @@ class SplashWithSignActivity :
         splashWithLoginLauncher.launch(
             Intent(this, OnboardingActivity::class.java)
         )
+    }
+
+    private fun checkAlarmPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && PackageManager.PERMISSION_DENIED == ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            )
+        ) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                REQUEST_PERMISSION_CODE
+            )
+
+        } else {
+            setAutoLogin()
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        when (requestCode) {
+            REQUEST_PERMISSION_CODE -> {
+                if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    startOnBoardingActivity() //권한 설정 완료
+                } else {
+                    //권한 설정 취소
+                    val intent: Intent =
+                        Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).setData(
+                            Uri.parse("package:" + this.packageName)
+                        )
+                    startActivity(intent)
+                    this.finish()
+                }
+            }
+        }
     }
 
     private fun isAlreadyUserObserver() {


### PR DESCRIPTION
- closed #894 

<img width="410" alt="image" src="https://github.com/TeamHavit/Havit-Android/assets/48551119/42e287c5-c3f7-40eb-9b0d-d11016c329c1">

<참고사항!>
- targetSdk 33 으로 변경해야 작동
- 앱 처음 설치했을 때만 요청팝업 뜸
- 스플래시 시작하자마자 요청팝업 뜨고 허용했을 시 온보딩 화면으로 넘어가고 거절했을 시 설정화면(알림 권한이 있는) 으로 넘어감. 즉 온보딩이 끝나고 나머지 원래 스플래시 애니메이션이 뜹니다!
- 안드로이드 버전 33 이하에서는 기본적으로 권한 ON 