### PR TITLE
[FIX] Android 13 Update & Deprecated된 onBackPressed 함수 제거 및 대처

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,12 +14,12 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 def kakao_native_app_key = properties.get('KAKAO_NATIVE_APP_KEY_NO_QUEOTS')
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "org.sopt.havit"
         minSdk 23
-        targetSdk 31
+        targetSdk 33
         versionCode 108
         versionName "1.0.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,7 +80,7 @@ android {
 dependencies {
 
     implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/app/src/main/java/org/sopt/havit/ui/category/CategoryContentModifyActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/category/CategoryContentModifyActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.MotionEvent
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.core.widget.addTextChangedListener
 import dagger.hilt.android.AndroidEntryPoint
@@ -33,8 +34,15 @@ class CategoryContentModifyActivity :
     private lateinit var iconAdapter: IconAdapter
     private lateinit var categoryTitleList: ArrayList<String>
 
+    private val callback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            setBackPressedAction()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        this.onBackPressedDispatcher.addCallback(this, callback)
         setContentView(binding.root)
 
         initIconAdapter()
@@ -46,10 +54,6 @@ class CategoryContentModifyActivity :
         setModifyCompleteBtnClickListener()
         observeDeleteState()
         observeModifyState()
-    }
-
-    override fun onBackPressed() {
-        setBackPressedAction()
     }
 
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {

--- a/app/src/main/java/org/sopt/havit/ui/category/CategoryOrderModifyActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/category/CategoryOrderModifyActivity.kt
@@ -3,6 +3,7 @@ package org.sopt.havit.ui.category
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
@@ -34,9 +35,16 @@ class CategoryOrderModifyActivity :
     private val originCategoryIdList = mutableListOf<Int>()
     lateinit var holder: RecyclerView.ViewHolder
 
+    private val callback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            setBackPressedAction()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+        this.onBackPressedDispatcher.addCallback(this, callback)
 
         initAdapter()
         setResult()
@@ -46,10 +54,6 @@ class CategoryOrderModifyActivity :
         initDrag()
         setCompleteOrder()
         observeOrderModifyState()
-    }
-
-    override fun onBackPressed() {
-        setBackPressedAction()
     }
 
     private fun setBackPressedAction() {

--- a/app/src/main/java/org/sopt/havit/ui/contents/more/BottomSheetMoreFragment.kt
+++ b/app/src/main/java/org/sopt/havit/ui/contents/more/BottomSheetMoreFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
@@ -30,11 +31,18 @@ class BottomSheetMoreFragment : BottomSheetDialogFragment() {
     var contents: ContentsMoreData? = null
     private lateinit var refreshDataOnBottomSheetDismiss: () -> Unit
 
+    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            if ((getCurrentFragmentOnMore() as? OnBackPressedHandler)?.onBackPressed() == false)
+                dismiss()
+        }
+    }
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return object : BottomSheetDialog(requireContext()) {
-            override fun onBackPressed() {
-                if ((getCurrentFragmentOnMore() as? OnBackPressedHandler)?.onBackPressed() == true) return
-                dismiss()
+            override fun onCreate(savedInstanceState: Bundle?) {
+                super.onCreate(savedInstanceState)
+                onBackPressedDispatcher.addCallback(viewLifecycleOwner, onBackPressedCallback)
             }
         }
     }
@@ -112,3 +120,4 @@ class BottomSheetMoreFragment : BottomSheetDialogFragment() {
         const val SET_ALARM = "SET_ALARM"
     }
 }
+

--- a/app/src/main/java/org/sopt/havit/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/onboarding/OnboardingActivity.kt
@@ -34,7 +34,7 @@ class OnboardingActivity :
     }
 
     private fun setIndicator() {
-        attachTo(viewPager)
+        binding.indicatorOnboarding.attachTo(binding.vpOnboarding)
     }
 
     private fun checkLastOnboardingPage() {

--- a/app/src/main/java/org/sopt/havit/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/onboarding/OnboardingActivity.kt
@@ -34,7 +34,7 @@ class OnboardingActivity :
     }
 
     private fun setIndicator() {
-        binding.indicatorOnboarding.setViewPager2(binding.vpOnboarding)
+        attachTo(viewPager)
     }
 
     private fun checkLastOnboardingPage() {
@@ -65,10 +65,6 @@ class OnboardingActivity :
         val intent = Intent(this, SplashWithSignActivity::class.java)
         setResult(RESULT_FIRST_USER, intent)
         finish()
-    }
-
-    override fun onBackPressed() {
-        // super.onBackPressed()    // 건너뛰기, 가입하기 버튼을 눌러야만
     }
 
     companion object {

--- a/app/src/main/java/org/sopt/havit/ui/setting/SettingPersonalDataActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/setting/SettingPersonalDataActivity.kt
@@ -9,6 +9,6 @@ class SettingPersonalDataActivity :
     BaseBindingActivity<ActivitySettingPersonalDataBinding>(R.layout.activity_setting_personal_data) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding.ivBack.setOnClickListener { super.onBackPressed() }
+        binding.ivBack.setOnClickListener { this.finish() }
     }
 }

--- a/app/src/main/java/org/sopt/havit/ui/setting/SettingPolicyActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/setting/SettingPolicyActivity.kt
@@ -9,6 +9,6 @@ class SettingPolicyActivity :
     BaseBindingActivity<ActivitySettingPolicyBinding>(R.layout.activity_setting_policy) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding.ivBack.setOnClickListener { super.onBackPressed() }
+        binding.ivBack.setOnClickListener { finish() }
     }
 }

--- a/app/src/main/java/org/sopt/havit/ui/share/BottomSheetShareFragment.kt
+++ b/app/src/main/java/org/sopt/havit/ui/share/BottomSheetShareFragment.kt
@@ -51,7 +51,7 @@ class BottomSheetShareFragment : BottomSheetDialogFragment() {
             override fun onBackPressed() {
                 if ((getTopmostFragmentOrNull() as? OnBackPressedHandler)?.onBackPressed() == true) return
                 val navController = binding.fcvShare.findNavController()
-                if (navController.graph.findStartDestination() == navController.currentDestination) super.onBackPressed()
+                if (navController.graph.findStartDestination() == navController.currentDestination) dismiss()
                 else navController.popBackStack()
             }
         }

--- a/app/src/main/java/org/sopt/havit/ui/share/BottomSheetShareFragment.kt
+++ b/app/src/main/java/org/sopt/havit/ui/share/BottomSheetShareFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.findNavController
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -20,6 +21,15 @@ import org.sopt.havit.util.getTopmostFragmentOrNull
 class BottomSheetShareFragment : BottomSheetDialogFragment() {
     private var _binding: FragmentBottomSheetShareBinding? = null
     private val binding get() = _binding!!
+
+    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            if ((getTopmostFragmentOrNull() as? OnBackPressedHandler)?.onBackPressed() == true) return
+            val navController = binding.fcvShare.findNavController()
+            if (navController.graph.findStartDestination() == navController.currentDestination) dismiss()
+            else navController.popBackStack()
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -48,11 +58,9 @@ class BottomSheetShareFragment : BottomSheetDialogFragment() {
     // 안드로이드 자체 뒤로가기 눌렀을 때 BackPressed 감지
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return object : BottomSheetDialog(requireContext(), R.style.AppBottomSheetDialogTheme) {
-            override fun onBackPressed() {
-                if ((getTopmostFragmentOrNull() as? OnBackPressedHandler)?.onBackPressed() == true) return
-                val navController = binding.fcvShare.findNavController()
-                if (navController.graph.findStartDestination() == navController.currentDestination) dismiss()
-                else navController.popBackStack()
+            override fun onCreate(savedInstanceState: Bundle?) {
+                super.onCreate(savedInstanceState)
+                onBackPressedDispatcher.addCallback(viewLifecycleOwner, onBackPressedCallback)
             }
         }
     }

--- a/app/src/main/java/org/sopt/havit/ui/sign/SplashWithSignActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/sign/SplashWithSignActivity.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.os.Bundle
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import dagger.hilt.android.AndroidEntryPoint
@@ -52,9 +53,18 @@ class SplashWithSignActivity :
         }
     }
 
+    private val callback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            finish()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+
+        this.onBackPressedDispatcher.addCallback(this, callback)
+
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         binding.main = signInViewModel
         initFcmToken()
@@ -184,10 +194,5 @@ class SplashWithSignActivity :
         if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
             super.setRequestedOrientation(requestedOrientation)
         }
-    }
-
-    override fun onBackPressed() {
-        super.onBackPressed()
-        finish()
     }
 }

--- a/app/src/main/java/org/sopt/havit/ui/web/WebActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/web/WebActivity.kt
@@ -7,6 +7,7 @@ import android.view.View.GONE
 import android.view.animation.AnimationUtils
 import android.webkit.*
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import com.bumptech.glide.Glide
 import dagger.hilt.android.AndroidEntryPoint
@@ -28,9 +29,18 @@ class WebActivity : BaseBindingActivity<ActivityWebBinding>(R.layout.activity_we
     private var startTime: Int = 0
     private var endTime: Int = 0
 
+    private val callback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            setBackPressedAction()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+
+        this.onBackPressedDispatcher.addCallback(this, callback)
+
         binding.vm = webViewModel
         startTime = SystemClock.elapsedRealtime().toInt()
         initIsHavit()
@@ -152,11 +162,9 @@ class WebActivity : BaseBindingActivity<ActivityWebBinding>(R.layout.activity_we
         GoogleAnalyticsUtil.logScreenDurationTimeEvent(CONTENT_SCREEN_TIME, endTime - startTime)
     }
 
-    override fun onBackPressed() {
-        super.onBackPressed()
+    private fun setBackPressedAction() {
         super.finish()
         setWebViewDurationTimeLogging()
         GoogleAnalyticsUtil.logClickEvent(CLICK_GO_BACK)
     }
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.4"
+        classpath 'com.android.tools.build:gradle:7.3.0'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10'
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.4.2"
         classpath 'com.google.gms:google-services:4.3.15'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jan 11 16:57:39 KST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- closed #891 

ex) 콘텐츠 타이틀 수정 후, 뒤로가기 시 경고 다이얼로그가 뜨는 기존 로직.
android 13 에서뒤로가기 버튼을 누르거나 스와이프 시, 기존 로직이 정상적으로 동작합니다.
|<img width="340" alt="image" src="https://github.com/TeamHavit/Havit-Android/assets/68214704/15a254b9-1094-4d9a-a53c-910bc376ae0a">|<img width="340" alt="image" src="https://github.com/TeamHavit/Havit-Android/assets/68214704/d1974844-5928-46d9-8255-ce272d326797">|