### PR TITLE
[FEAT] 강제 업데이트 구현 #905

### DIFF
--- a/app/src/main/java/org/sopt/havit/data/repository/SystemMaintenanceRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/havit/data/repository/SystemMaintenanceRepositoryImpl.kt
@@ -1,5 +1,10 @@
 package org.sopt.havit.data.repository
 
+import com.google.firebase.crashlytics.ktx.crashlytics
+import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
 import org.sopt.havit.data.source.remote.RemoteConfigDataSource
 import org.sopt.havit.domain.repository.SystemMaintenanceRepository
 import javax.inject.Inject
@@ -23,9 +28,23 @@ class SystemMaintenanceRepositoryImpl @Inject constructor(
         return message.ifEmpty { DEFAULT_MESSAGE }
     }
 
+    override fun getForcedUpdateVer(): Flow<Int> = flow {
+        systemMaintenanceRemoteDataSource.fetchRemoteConfigFlow(
+            ANDROID_FORCED_UPDATE_VER,
+            Long::class.java
+        ).catch {
+            Firebase.crashlytics.recordException(it)
+            emit(0)
+        }.collect {
+            emit((it as? Long)?.toInt() ?: 0)
+        }
+    }
+
+
     companion object {
         private const val IS_SYSTEM_UNDER_MAINTENANCE = "isSystemUnderMaintenance"
         private const val SYSTEM_MAINTENANCE_MESSAGE = "systemMaintenanceMessage"
+        private const val ANDROID_FORCED_UPDATE_VER = "androidForcedUpdateVer"
         private const val DEFAULT_MESSAGE = "현재 시스템 점검중입니다.\\n불편을 끼쳐드려 죄송합니다."
     }
 }

--- a/app/src/main/java/org/sopt/havit/data/source/remote/RemoteConfigDataSource.kt
+++ b/app/src/main/java/org/sopt/havit/data/source/remote/RemoteConfigDataSource.kt
@@ -1,7 +1,9 @@
 package org.sopt.havit.data.source.remote
 
+import kotlinx.coroutines.flow.Flow
 import java.lang.reflect.Type
 
 interface RemoteConfigDataSource {
     suspend fun fetchRemoteConfig(configKey: String, valueType: Type): Any
+    fun fetchRemoteConfigFlow(configKey: String, valueType: Type): Flow<Any>
 }

--- a/app/src/main/java/org/sopt/havit/domain/repository/SystemMaintenanceRepository.kt
+++ b/app/src/main/java/org/sopt/havit/domain/repository/SystemMaintenanceRepository.kt
@@ -1,8 +1,12 @@
 package org.sopt.havit.domain.repository
 
+import kotlinx.coroutines.flow.Flow
+
 interface SystemMaintenanceRepository {
 
     suspend fun isSystemMaintenance(): Boolean
 
     suspend fun getSystemMaintenanceMessage(): String
+
+    fun getForcedUpdateVer(): Flow<Int>
 }

--- a/app/src/main/java/org/sopt/havit/ui/base/BaseActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/base/BaseActivity.kt
@@ -8,9 +8,10 @@ import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.lifecycle.Observer
 import org.sopt.havit.ui.system_maintenance.SystemMaintenanceActivity
+import org.sopt.havit.util.DialogOkUtil
 
 
-abstract class BaseBindingActivity<T : ViewDataBinding>(
+abstract class BaseActivity<T : ViewDataBinding>(
     @LayoutRes private val layoutRes: Int,
 ) : AppCompatActivity() {
     lateinit var binding: T

--- a/app/src/main/java/org/sopt/havit/ui/base/BaseActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/base/BaseActivity.kt
@@ -30,5 +30,16 @@ abstract class BaseActivity<T : ViewDataBinding>(
         startActivity(Intent(this, SystemMaintenanceActivity::class.java))
         finish()
     }
+
+    fun showForcedUpdateNeededDialog() {
+        val dialog = DialogOkUtil(DialogOkUtil.FORCED_UPDATE, ::moveToPlayStore, false)
+        dialog.show(this.supportFragmentManager, this.javaClass.name)
+    }
+
+    private fun moveToPlayStore() {
+        val intent = Intent(Intent.ACTION_VIEW)
+        intent.data = android.net.Uri.parse("market://details?id=org.sopt.havit")
+        startActivity(intent)
+    }
 }
 

--- a/app/src/main/java/org/sopt/havit/ui/base/BaseActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/base/BaseActivity.kt
@@ -31,9 +31,15 @@ abstract class BaseActivity<T : ViewDataBinding>(
         finish()
     }
 
-    fun showForcedUpdateNeededDialog() {
+    private fun showForcedUpdateNeededDialog() {
         val dialog = DialogOkUtil(DialogOkUtil.FORCED_UPDATE, ::moveToPlayStore, false)
         dialog.show(this.supportFragmentManager, this.javaClass.name)
+    }
+
+    fun showForcedUpdateDialogIfNeeded(isForcedUpdateNeeded: Boolean) {
+        if (isForcedUpdateNeeded) {
+            showForcedUpdateNeededDialog()
+        }
     }
 
     private fun moveToPlayStore() {

--- a/app/src/main/java/org/sopt/havit/ui/base/BaseViewModel.kt
+++ b/app/src/main/java/org/sopt/havit/ui/base/BaseViewModel.kt
@@ -1,11 +1,16 @@
 package org.sopt.havit.ui.base
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import org.sopt.havit.BuildConfig
+import org.sopt.havit.HavitFirebaseMessagingService.Companion.TAG
 import org.sopt.havit.domain.repository.SystemMaintenanceRepository
 import javax.inject.Inject
 
@@ -14,14 +19,31 @@ open class BaseViewModel @Inject constructor(
     private val systemMaintenanceRepository: SystemMaintenanceRepository,
 ) : ViewModel() {
 
-
     private val _isSystemMaintenance: MutableLiveData<Boolean> = MutableLiveData()
     val isSystemMaintenance: LiveData<Boolean> = _isSystemMaintenance
 
+    private val _isForcedUpdatedNeeded: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isForcedUpdatedNeeded: StateFlow<Boolean> = _isForcedUpdatedNeeded
 
-    fun fetchIsSystemMaintenance() {
+    init {
+        fetchIsSystemMaintenance()
+        fetchIsForcedUpdated()
+    }
+
+
+    private fun fetchIsSystemMaintenance() {
         viewModelScope.launch {
             _isSystemMaintenance.postValue(systemMaintenanceRepository.isSystemMaintenance())
+        }
+    }
+
+    private fun fetchIsForcedUpdated() {
+        viewModelScope.launch {
+            systemMaintenanceRepository.getForcedUpdateVer()
+                .collect {
+                    _isForcedUpdatedNeeded.value = it > BuildConfig.VERSION_CODE
+                    Log.d(TAG, "fetchIsForcedUpdated: $it")
+                }
         }
     }
 }

--- a/app/src/main/java/org/sopt/havit/ui/category/CategoryContentModifyActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/category/CategoryContentModifyActivity.kt
@@ -13,7 +13,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivityCategoryContentModifyBinding
 import org.sopt.havit.domain.entity.NetworkState
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.category.CategoryFragment.Companion.CATEGORY_ID
 import org.sopt.havit.ui.category.CategoryFragment.Companion.CATEGORY_IMAGE_ID
 import org.sopt.havit.ui.category.CategoryFragment.Companion.CATEGORY_NAME
@@ -21,11 +21,16 @@ import org.sopt.havit.ui.category.CategoryFragment.Companion.CATEGORY_NAME_LIST
 import org.sopt.havit.ui.category.CategoryFragment.Companion.CATEGORY_POSITION
 import org.sopt.havit.ui.share.add_category.IconAdapter
 import org.sopt.havit.ui.share.add_category.IconAdapter.Companion.clickedPosition
-import org.sopt.havit.util.*
+import org.sopt.havit.util.CATEGORY_MODIFY_COMPLETE_TYPE
+import org.sopt.havit.util.DELETE_CATEGORY_TOP_TYPE
+import org.sopt.havit.util.DialogUtil
+import org.sopt.havit.util.ERROR_OCCUR_TYPE
+import org.sopt.havit.util.ToastUtil
+import org.sopt.havit.util.setOnSingleClickListener
 
 @AndroidEntryPoint
 class CategoryContentModifyActivity :
-    BaseBindingActivity<ActivityCategoryContentModifyBinding>(R.layout.activity_category_content_modify) {
+    BaseActivity<ActivityCategoryContentModifyBinding>(R.layout.activity_category_content_modify) {
     private val categoryViewModel by viewModels<CategoryViewModel>()
     private var position = -1
     private var id = -1

--- a/app/src/main/java/org/sopt/havit/ui/category/CategoryOrderModifyActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/category/CategoryOrderModifyActivity.kt
@@ -13,7 +13,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivityCategoryOrderModifyBinding
 import org.sopt.havit.domain.entity.NetworkState
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.category.CategoryContentModifyActivity.Companion.RESULT_DELETE_CATEGORY
 import org.sopt.havit.ui.category.CategoryContentModifyActivity.Companion.RESULT_MODIFY_CATEGORY
 import org.sopt.havit.ui.category.CategoryFragment.Companion.CATEGORY_ID
@@ -28,7 +28,7 @@ import org.sopt.havit.util.setOnSingleClickListener
 
 @AndroidEntryPoint
 class CategoryOrderModifyActivity :
-    BaseBindingActivity<ActivityCategoryOrderModifyBinding>(R.layout.activity_category_order_modify) {
+    BaseActivity<ActivityCategoryOrderModifyBinding>(R.layout.activity_category_order_modify) {
     private lateinit var getResult: ActivityResultLauncher<Intent>
     private lateinit var categoryOrderModifyAdapter: CategoryOrderModifyAdapter
     private val categoryViewModel by viewModels<CategoryViewModel>()

--- a/app/src/main/java/org/sopt/havit/ui/contents/ContentsActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/contents/ContentsActivity.kt
@@ -16,7 +16,7 @@ import org.sopt.havit.R
 import org.sopt.havit.data.remote.ContentsMoreData
 import org.sopt.havit.databinding.ActivityContentsBinding
 import org.sopt.havit.domain.entity.NetworkState
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.category.CategoryContentModifyActivity
 import org.sopt.havit.ui.category.CategoryContentModifyActivity.Companion.RESULT_DELETE_CATEGORY
 import org.sopt.havit.ui.category.CategoryContentModifyActivity.Companion.RESULT_MODIFY_CATEGORY
@@ -32,11 +32,17 @@ import org.sopt.havit.ui.contents.more.ContentsMoreFragment
 import org.sopt.havit.ui.save.SaveFragment
 import org.sopt.havit.ui.search.SearchActivity
 import org.sopt.havit.ui.web.WebActivity
-import org.sopt.havit.util.*
+import org.sopt.havit.util.CONTENT_CHECK_COMPLETE_TYPE
+import org.sopt.havit.util.CONTENT_DELETE_TYPE
+import org.sopt.havit.util.DialogUtil
+import org.sopt.havit.util.ERROR_OCCUR_TYPE
+import org.sopt.havit.util.GoogleAnalyticsUtil
+import org.sopt.havit.util.ToastUtil
+import org.sopt.havit.util.setOnSingleClickListener
 import java.io.Serializable
 
 @AndroidEntryPoint
-class ContentsActivity : BaseBindingActivity<ActivityContentsBinding>(R.layout.activity_contents) {
+class ContentsActivity : BaseActivity<ActivityContentsBinding>(R.layout.activity_contents) {
     private lateinit var contentsAdapter: ContentsAdapter
     private val contentsViewModel: ContentsViewModel by viewModels()
     private val categoryViewModel: CategoryViewModel by viewModels()

--- a/app/src/main/java/org/sopt/havit/ui/contents_simple/ContentsSimpleActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/contents_simple/ContentsSimpleActivity.kt
@@ -13,17 +13,22 @@ import org.sopt.havit.R
 import org.sopt.havit.data.remote.ContentsMoreData
 import org.sopt.havit.databinding.ActivityContentsSimpleBinding
 import org.sopt.havit.domain.entity.NetworkState
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.contents.more.ContentsMoreFragment
 import org.sopt.havit.ui.home.HomeFragment
 import org.sopt.havit.ui.save.SaveFragment
 import org.sopt.havit.ui.web.WebActivity
-import org.sopt.havit.util.*
+import org.sopt.havit.util.CONTENT_CHECK_COMPLETE_TYPE
+import org.sopt.havit.util.CONTENT_DELETE_TYPE
+import org.sopt.havit.util.CustomDecoration
+import org.sopt.havit.util.DialogUtil
+import org.sopt.havit.util.ToastUtil
+import org.sopt.havit.util.setOnSingleClickListener
 import java.io.Serializable
 
 @AndroidEntryPoint
 class ContentsSimpleActivity :
-    BaseBindingActivity<ActivityContentsSimpleBinding>(R.layout.activity_contents_simple) {
+    BaseActivity<ActivityContentsSimpleBinding>(R.layout.activity_contents_simple) {
 
     private val contentsViewModel: ContentsSimpleViewModel by viewModels()
     private lateinit var contentsAdapter: ContentsSimpleRvAdapter

--- a/app/src/main/java/org/sopt/havit/ui/mypage/ContentsFromMyPageActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/mypage/ContentsFromMyPageActivity.kt
@@ -5,13 +5,13 @@ import android.os.Bundle
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivityContentsFromMyPageBinding
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.category.CategoryFragment
 import org.sopt.havit.ui.contents.ContentsActivity
 
 @AndroidEntryPoint
 class ContentsFromMyPageActivity :
-    BaseBindingActivity<ActivityContentsFromMyPageBinding>(R.layout.activity_contents_from_my_page) {
+    BaseActivity<ActivityContentsFromMyPageBinding>(R.layout.activity_contents_from_my_page) {
 
     private var pageId = 0
 

--- a/app/src/main/java/org/sopt/havit/ui/notification/NotificationActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/notification/NotificationActivity.kt
@@ -13,7 +13,7 @@ import org.sopt.havit.R
 import org.sopt.havit.data.remote.ContentsMoreData
 import org.sopt.havit.data.remote.NotificationResponse
 import org.sopt.havit.databinding.ActivityNotificationBinding
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.contents.more.ContentsMoreFragment
 import org.sopt.havit.ui.web.WebActivity
 import org.sopt.havit.util.CONTENT_CHECK_COMPLETE_TYPE
@@ -24,7 +24,7 @@ import java.io.Serializable
 
 @AndroidEntryPoint
 class NotificationActivity :
-    BaseBindingActivity<ActivityNotificationBinding>(R.layout.activity_notification) {
+    BaseActivity<ActivityNotificationBinding>(R.layout.activity_notification) {
     private val notificationViewModel: NotificationViewModel by viewModels()
     private lateinit var notificationAdapter: NotificationRvAdapter
 

--- a/app/src/main/java/org/sopt/havit/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/onboarding/OnboardingActivity.kt
@@ -6,14 +6,14 @@ import androidx.viewpager2.widget.ViewPager2
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivityOnboardingBinding
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.sign.SplashWithSignActivity
 import org.sopt.havit.util.HavitSharedPreference
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class OnboardingActivity :
-    BaseBindingActivity<ActivityOnboardingBinding>(R.layout.activity_onboarding) {
+    BaseActivity<ActivityOnboardingBinding>(R.layout.activity_onboarding) {
 
     @Inject
     lateinit var preference: HavitSharedPreference

--- a/app/src/main/java/org/sopt/havit/ui/search/SearchActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/search/SearchActivity.kt
@@ -13,7 +13,7 @@ import org.sopt.havit.R
 import org.sopt.havit.data.remote.ContentsMoreData
 import org.sopt.havit.databinding.ActivitySearchBinding
 import org.sopt.havit.domain.entity.Contents
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.contents.more.ContentsMoreFragment
 import org.sopt.havit.ui.web.WebActivity
 import org.sopt.havit.util.DialogUtil
@@ -22,7 +22,7 @@ import org.sopt.havit.util.KeyBoardUtil
 import java.io.Serializable
 
 @AndroidEntryPoint
-class SearchActivity : BaseBindingActivity<ActivitySearchBinding>(R.layout.activity_search) {
+class SearchActivity : BaseActivity<ActivitySearchBinding>(R.layout.activity_search) {
 
     private val searchViewModel: SearchViewModel by viewModels()
     private val searchContentsAdapter: SearchContentsAdapter by lazy { SearchContentsAdapter() }

--- a/app/src/main/java/org/sopt/havit/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/setting/SettingActivity.kt
@@ -11,7 +11,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivitySettingBinding
 import org.sopt.havit.domain.entity.VersionState
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.home.ServiceGuideActivity
 import org.sopt.havit.ui.setting.viewmodel.SettingViewModel
 import org.sopt.havit.ui.sign.SplashWithSignActivity
@@ -24,7 +24,7 @@ import org.sopt.havit.util.setOnSingleClickListener
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class SettingActivity : BaseBindingActivity<ActivitySettingBinding>(R.layout.activity_setting) {
+class SettingActivity : BaseActivity<ActivitySettingBinding>(R.layout.activity_setting) {
     private val settingViewModel: SettingViewModel by viewModels()
 
     @Inject

--- a/app/src/main/java/org/sopt/havit/ui/setting/SettingAlarmActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/setting/SettingAlarmActivity.kt
@@ -5,12 +5,12 @@ import androidx.activity.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivitySettingAlarmBinding
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.setting.viewmodel.SettingAlarmViewModel
 
 @AndroidEntryPoint
 class SettingAlarmActivity :
-    BaseBindingActivity<ActivitySettingAlarmBinding>(R.layout.activity_setting_alarm) {
+    BaseActivity<ActivitySettingAlarmBinding>(R.layout.activity_setting_alarm) {
     private val viewModel: SettingAlarmViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/sopt/havit/ui/setting/SettingModifyNicknameActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/setting/SettingModifyNicknameActivity.kt
@@ -6,14 +6,14 @@ import androidx.core.widget.addTextChangedListener
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivitySettingModifyNicknameBinding
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.setting.viewmodel.SettingViewModel
 import org.sopt.havit.util.KeyBoardUtil.setUpAsSoftKeyboard
 import org.sopt.havit.util.setOnSinglePostClickListener
 
 @AndroidEntryPoint
 class SettingModifyNicknameActivity :
-    BaseBindingActivity<ActivitySettingModifyNicknameBinding>(R.layout.activity_setting_modify_nickname) {
+    BaseActivity<ActivitySettingModifyNicknameBinding>(R.layout.activity_setting_modify_nickname) {
     private val settingViewModel: SettingViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/sopt/havit/ui/setting/SettingNoticeActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/setting/SettingNoticeActivity.kt
@@ -7,14 +7,14 @@ import androidx.activity.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivitySettingNoticeBinding
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.setting.adapter.NoticeAdapter
 import org.sopt.havit.ui.setting.viewmodel.SettingViewModel
 import org.sopt.havit.util.setOnSingleClickListener
 
 @AndroidEntryPoint
 class SettingNoticeActivity :
-    BaseBindingActivity<ActivitySettingNoticeBinding>(R.layout.activity_setting_notice) {
+    BaseActivity<ActivitySettingNoticeBinding>(R.layout.activity_setting_notice) {
     private val viewModel: SettingViewModel by viewModels()
     private lateinit var noticeAdapter: NoticeAdapter
 

--- a/app/src/main/java/org/sopt/havit/ui/setting/SettingPersonalDataActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/setting/SettingPersonalDataActivity.kt
@@ -3,10 +3,10 @@ package org.sopt.havit.ui.setting
 import android.os.Bundle
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivitySettingPersonalDataBinding
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 
 class SettingPersonalDataActivity :
-    BaseBindingActivity<ActivitySettingPersonalDataBinding>(R.layout.activity_setting_personal_data) {
+    BaseActivity<ActivitySettingPersonalDataBinding>(R.layout.activity_setting_personal_data) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.ivBack.setOnClickListener { this.finish() }

--- a/app/src/main/java/org/sopt/havit/ui/setting/SettingPolicyActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/setting/SettingPolicyActivity.kt
@@ -3,10 +3,10 @@ package org.sopt.havit.ui.setting
 import android.os.Bundle
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivitySettingPolicyBinding
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 
 class SettingPolicyActivity :
-    BaseBindingActivity<ActivitySettingPolicyBinding>(R.layout.activity_setting_policy) {
+    BaseActivity<ActivitySettingPolicyBinding>(R.layout.activity_setting_policy) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.ivBack.setOnClickListener { finish() }

--- a/app/src/main/java/org/sopt/havit/ui/setting/SettingUnregisterActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/setting/SettingUnregisterActivity.kt
@@ -8,7 +8,7 @@ import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivitySettingUnregisterBinding
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.setting.viewmodel.SettingViewModel
 import org.sopt.havit.ui.sign.SplashWithSignActivity
 import org.sopt.havit.util.DialogOkUtil
@@ -17,7 +17,7 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class SettingUnregisterActivity :
-    BaseBindingActivity<ActivitySettingUnregisterBinding>(R.layout.activity_setting_unregister) {
+    BaseActivity<ActivitySettingUnregisterBinding>(R.layout.activity_setting_unregister) {
     private val settingViewModel: SettingViewModel by viewModels()
 
     @Inject

--- a/app/src/main/java/org/sopt/havit/ui/share/ShareActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/share/ShareActivity.kt
@@ -32,7 +32,6 @@ class ShareActivity : BaseBindingActivity<ActivityShareBinding>(R.layout.activit
         shareViewModel.fetchIsSystemMaintenance()
         observeSystemUnderMaintenance()
         setScreenOrientation()
-        initializeActivityResultLauncher()
         handleShareFlow()
     }
 
@@ -70,6 +69,7 @@ class ShareActivity : BaseBindingActivity<ActivityShareBinding>(R.layout.activit
     }
 
     private fun moveToSplashWithSign() {
+        initializeActivityResultLauncher()
         val intent = Intent(this, SplashWithSignActivity::class.java).apply {
             putExtra(WHERE_SPLASH_COME_FROM, SPLASH_FROM_SHARE)
         }

--- a/app/src/main/java/org/sopt/havit/ui/share/ShareActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/share/ShareActivity.kt
@@ -134,12 +134,6 @@ class ShareActivity : BaseActivity<ActivityShareBinding>(R.layout.activity_share
         }
     }
 
-    private fun showForcedUpdateDialogIfNeeded(isForcedUpdateNeeded: Boolean) {
-        if (isForcedUpdateNeeded) {
-            showForcedUpdateNeededDialog()
-        }
-    }
-
     companion object {
         const val WHERE_SPLASH_COME_FROM = "WHERE_SPLASH_COME_FROM"
         const val ON_NETWORK_ERROR_DISMISS = "ON_NETWORK_ERROR_DISMISS"

--- a/app/src/main/java/org/sopt/havit/ui/share/ShareActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/share/ShareActivity.kt
@@ -10,10 +10,12 @@ import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivityShareBinding
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.sign.SignInViewModel.Companion.SPLASH_FROM_SHARE
 import org.sopt.havit.ui.sign.SplashWithSignActivity
 import org.sopt.havit.util.INVALID_URL_TYPE
@@ -21,7 +23,7 @@ import org.sopt.havit.util.ToastUtil
 import java.io.Serializable
 
 @AndroidEntryPoint
-class ShareActivity : BaseBindingActivity<ActivityShareBinding>(R.layout.activity_share) {
+class ShareActivity : BaseActivity<ActivityShareBinding>(R.layout.activity_share) {
 
     private val shareViewModel: ShareViewModel by viewModels()
     private lateinit var splashWithSignLauncher: ActivityResultLauncher<Intent>

--- a/app/src/main/java/org/sopt/havit/ui/share/ShareActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/share/ShareActivity.kt
@@ -65,7 +65,10 @@ class ShareActivity : BaseActivity<ActivityShareBinding>(R.layout.activity_share
         shareViewModel.makeSignIn(
             internetError = { showNetworkErrorBottomSheet() },
             onUnAuthorized = { moveToSplashWithSign() },
-            onAuthorized = { showShareBottomSheet() }
+            onAuthorized = {
+                showShareBottomSheet()
+                isForcedUpdateNeeded()
+            }
         )
     }
 
@@ -122,6 +125,19 @@ class ShareActivity : BaseActivity<ActivityShareBinding>(R.layout.activity_share
 
     private fun observeSystemUnderMaintenance() {
         shareViewModel.isSystemMaintenance.observe(this, systemMaintenanceObserver)
+    }
+
+    private fun isForcedUpdateNeeded() {
+        lifecycleScope.launch {
+            shareViewModel.isForcedUpdatedNeeded
+                .collect(::showForcedUpdateDialogIfNeeded)
+        }
+    }
+
+    private fun showForcedUpdateDialogIfNeeded(isForcedUpdateNeeded: Boolean) {
+        if (isForcedUpdateNeeded) {
+            showForcedUpdateNeededDialog()
+        }
     }
 
     companion object {

--- a/app/src/main/java/org/sopt/havit/ui/share/ShareActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/share/ShareActivity.kt
@@ -31,7 +31,6 @@ class ShareActivity : BaseActivity<ActivityShareBinding>(R.layout.activity_share
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        shareViewModel.fetchIsSystemMaintenance()
         observeSystemUnderMaintenance()
         setScreenOrientation()
         handleShareFlow()

--- a/app/src/main/java/org/sopt/havit/ui/sign/SignUpActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/sign/SignUpActivity.kt
@@ -5,11 +5,11 @@ import androidx.activity.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivitySignUpBinding
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.util.EventObserver
 
 @AndroidEntryPoint
-class SignUpActivity : BaseBindingActivity<ActivitySignUpBinding>(R.layout.activity_sign_up) {
+class SignUpActivity : BaseActivity<ActivitySignUpBinding>(R.layout.activity_sign_up) {
 
     private val signUpViewModel: SignUpViewModel by viewModels()
     private val signVpAdapter: SignVpAdapter by lazy { SignVpAdapter(this) }

--- a/app/src/main/java/org/sopt/havit/ui/sign/SplashWithSignActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/sign/SplashWithSignActivity.kt
@@ -75,7 +75,6 @@ class SplashWithSignActivity :
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         binding.main = signInViewModel
 
-        signInViewModel.fetchIsSystemMaintenance()
         observeSystemUnderMaintenance()
         initFcmToken()
         initSuccessKakaoLoginObserver()

--- a/app/src/main/java/org/sopt/havit/ui/sign/SplashWithSignActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/sign/SplashWithSignActivity.kt
@@ -16,7 +16,9 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.sopt.havit.MainActivity
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivitySplashWithSignBinding
@@ -246,6 +248,13 @@ class SplashWithSignActivity :
     override fun setRequestedOrientation(requestedOrientation: Int) {
         if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
             super.setRequestedOrientation(requestedOrientation)
+        }
+    }
+
+    private fun isForcedUpdateNeeded() {
+        lifecycleScope.launch {
+            signInViewModel.isForcedUpdatedNeeded
+                .collect(::showForcedUpdateDialogIfNeeded)
         }
     }
 }

--- a/app/src/main/java/org/sopt/havit/ui/sign/SplashWithSignActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/sign/SplashWithSignActivity.kt
@@ -21,7 +21,7 @@ import org.sopt.havit.MainActivity
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivitySplashWithSignBinding
 import org.sopt.havit.domain.entity.NetworkState
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.ui.onboarding.OnboardingActivity
 import org.sopt.havit.ui.share.ShareActivity
 import org.sopt.havit.ui.sign.SignInViewModel.Companion.SPLASH_NORMAL_FLOW
@@ -34,7 +34,7 @@ import kotlin.properties.Delegates
 
 @AndroidEntryPoint
 class SplashWithSignActivity :
-    BaseBindingActivity<ActivitySplashWithSignBinding>(R.layout.activity_splash_with_sign) {
+    BaseActivity<ActivitySplashWithSignBinding>(R.layout.activity_splash_with_sign) {
 
     @Inject
     lateinit var preference: HavitSharedPreference

--- a/app/src/main/java/org/sopt/havit/ui/system_maintenance/SystemMaintenanceActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/system_maintenance/SystemMaintenanceActivity.kt
@@ -5,11 +5,11 @@ import androidx.activity.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivitySystemMaintenanceBinding
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 
 @AndroidEntryPoint
 class SystemMaintenanceActivity :
-    BaseBindingActivity<ActivitySystemMaintenanceBinding>(R.layout.activity_system_maintenance) {
+    BaseActivity<ActivitySystemMaintenanceBinding>(R.layout.activity_system_maintenance) {
 
     private val systemMaintenanceViewModel: SystemMaintenanceViewModel by viewModels()
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/sopt/havit/ui/web/WebActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/web/WebActivity.kt
@@ -18,7 +18,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivityWebBinding
 import org.sopt.havit.domain.entity.NetworkState
-import org.sopt.havit.ui.base.BaseBindingActivity
+import org.sopt.havit.ui.base.BaseActivity
 import org.sopt.havit.util.EventObserver
 import org.sopt.havit.util.GoogleAnalyticsUtil
 import org.sopt.havit.util.GoogleAnalyticsUtil.CLICK_GO_BACK
@@ -27,7 +27,7 @@ import org.sopt.havit.util.GoogleAnalyticsUtil.CLICK_SHARE
 import org.sopt.havit.util.GoogleAnalyticsUtil.CONTENT_SCREEN_TIME
 
 @AndroidEntryPoint
-class WebActivity : BaseBindingActivity<ActivityWebBinding>(R.layout.activity_web) {
+class WebActivity : BaseActivity<ActivityWebBinding>(R.layout.activity_web) {
 
     private val webViewModel: WebViewModel by viewModels()
     private var startTime: Int = 0

--- a/app/src/main/java/org/sopt/havit/ui/web/WebActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/web/WebActivity.kt
@@ -13,8 +13,10 @@ import android.webkit.WebViewClient
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.sopt.havit.R
 import org.sopt.havit.databinding.ActivityWebBinding
 import org.sopt.havit.domain.entity.NetworkState
@@ -53,6 +55,11 @@ class WebActivity : BaseActivity<ActivityWebBinding>(R.layout.activity_web) {
         setUrlCheck()
         setListeners()
         initIsHavitObserver()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        isForcedUpdateNeeded()
     }
 
     private fun initIsHavit() {
@@ -175,5 +182,12 @@ class WebActivity : BaseActivity<ActivityWebBinding>(R.layout.activity_web) {
 
     private fun observeSystemUnderMaintenance() {
         webViewModel.isSystemMaintenance.observe(this, systemMaintenanceObserver)
+    }
+
+    private fun isForcedUpdateNeeded() {
+        lifecycleScope.launch {
+            webViewModel.isForcedUpdatedNeeded
+                .collect(::showForcedUpdateDialogIfNeeded)
+        }
     }
 }

--- a/app/src/main/java/org/sopt/havit/ui/web/WebActivity.kt
+++ b/app/src/main/java/org/sopt/havit/ui/web/WebActivity.kt
@@ -47,7 +47,6 @@ class WebActivity : BaseActivity<ActivityWebBinding>(R.layout.activity_web) {
         binding.vm = webViewModel
         startTime = SystemClock.elapsedRealtime().toInt()
 
-        webViewModel.fetchIsSystemMaintenance()
         observeSystemUnderMaintenance()
         initIsHavit()
         initHavitSeen()

--- a/app/src/main/java/org/sopt/havit/util/DialogOkUtil.kt
+++ b/app/src/main/java/org/sopt/havit/util/DialogOkUtil.kt
@@ -1,6 +1,7 @@
 package org.sopt.havit.util
 
 import android.app.Dialog
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -9,7 +10,11 @@ import androidx.fragment.app.DialogFragment
 import org.sopt.havit.R
 import org.sopt.havit.databinding.DialogOkUtilBinding
 
-class DialogOkUtil(private val dialogMode: Int, private val doAfterConfirm: () -> Unit) :
+class DialogOkUtil(
+    private val dialogMode: Int,
+    private val doAfterConfirm: () -> Unit,
+    private val dismissAvailability: Boolean = true,
+) :
     DialogFragment() {
     private var _binding: DialogOkUtilBinding? = null
     val binding get() = _binding!!
@@ -34,6 +39,7 @@ class DialogOkUtil(private val dialogMode: Int, private val doAfterConfirm: () -
         setConfirmText()
         setConfirmBackground()
         clickListener()
+        setDismissUnable()
     }
 
     private fun setLayout(view: View) {
@@ -43,44 +49,65 @@ class DialogOkUtil(private val dialogMode: Int, private val doAfterConfirm: () -
     private fun setTitle() {
         binding.title = when (dialogMode) {
             UNREGISTER -> getString(R.string.unregister_complete)
-            else -> throw IllegalStateException()
+            FORCED_UPDATE -> getString(R.string.update_notification)
+            else -> ""
         }
     }
 
     private fun setDescription() {
         binding.description = when (dialogMode) {
             UNREGISTER -> getString(R.string.unregister_complete_description)
-            else -> throw IllegalStateException()
+            FORCED_UPDATE -> getString(R.string.update_notification_description)
+            else -> ""
         }
     }
 
     private fun setConfirmText() {
         binding.confirmText = when (dialogMode) {
             UNREGISTER -> getString(R.string.check)
-            else -> throw IllegalStateException()
+            FORCED_UPDATE -> getString(R.string.update)
+            else -> ""
         }
     }
 
     private fun setConfirmBackground() {
-        when (dialogMode) {
-            UNREGISTER -> binding.btnConfirm.setBackgroundResource(R.drawable.rectangle_havit_gray_bottom_radius_8)
-            else -> throw IllegalStateException()
+        val res = when (dialogMode) {
+            UNREGISTER -> R.drawable.rectangle_havit_gray_bottom_radius_8
+            FORCED_UPDATE -> R.drawable.rectangle_havit_purple_bottom_radius_8
+            else -> R.drawable.rectangle_havit_gray_bottom_radius_8
         }
+        binding.btnConfirm.setBackgroundResource(res)
     }
 
     private fun clickListener() {
         binding.ivClose.setOnSingleClickListener { dismiss() }
-        binding.btnConfirm.setOnSinglePostClickListener { dismiss() }
+        binding.btnConfirm.setOnSinglePostClickListener {
+            doAfterConfirm()
+            dismiss()
+        }
+    }
+
+    private fun setDismissUnable() {
+        if (!dismissAvailability) {
+            binding.ivClose.visibility = View.GONE
+            isCancelable = false
+        }
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        if (dismissAvailability) {
+            super.onCancel(dialog)
+        }
     }
 
     override fun onDestroyView() {
-        doAfterConfirm()
         super.onDestroyView()
         _binding = null
     }
 
     companion object {
         const val UNREGISTER = 0
+        const val FORCED_UPDATE = 1
     }
 
 }

--- a/app/src/main/res/drawable/rectangle_havit_purple_bottom_radius_8.xml
+++ b/app/src/main/res/drawable/rectangle_havit_purple_bottom_radius_8.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners
+        android:bottomLeftRadius="8dp"
+        android:bottomRightRadius="8dp" />
+    <solid android:color="@color/havit_purple" />
+</shape>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -286,5 +286,7 @@
     <string name="disable_whitespace_on_nickname">닉네임에 띄어쓰기는 사용할 수 없습니다.</string>
     <string name="system_under_maintenance">시스템 점검 안내</string>
     <string name="invalid_url">유효하지 않은 URL입니다.</string>
+    <string name="update_notification">업데이트 알림</string>
+    <string name="update_notification_description">새로운 버전이 출시되었습니다.\n업데이트 후 이용해 주시기 바랍니다.</string>
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -18,6 +18,16 @@
 
     </style>
 
+    <style name="Theme.ForcedUpdateTransparent" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">true</item>
+    </style>
+
+
     <style name="Theme.RemoveSplash" parent="Theme.Havit">
         <item name="android:windowIsTranslucent">true</item>
     </style>


### PR DESCRIPTION
- closed #905 

### 변경사항 ❗️
- 네이밍 수정 (`BaseBindingActivity` -> `BaseActivity`)
- 기존에 binding 로직만 있던 `BaseBindingActivity`에, **시스템 유지보수 확인** 및 **강제 업데이트 확인** 로직이 추가됨에 따라 네이밍을 변경했습니다!


### 수정되어야 할 부분 
- SplashWithSignActivity에 의존성이 복잡해서 해당 부분만 강제업데이트 로직 추가해주시면 감사하겠습니다! @ny2060 
- 작업 브랜치는` feat/in-app-update` 입니다

### 구현 된 부분
- 해당 class 최하단에 `isForcedUpdateNeeded()` 함수 추가해뒀습니다.
- 이 함수는 강제업데이트가 필요한 상황에 '강제 업데이트가 필요합니다' 라는 다이얼로그를 띄우는 함수입니다.
- BaseViewModel의 initialize 시점에 서버 호출 로직이 작성되어 있으므로, 강제업데이트 확인 api 연동 및 UI는 추가적으로 작업하실 부분은 없습니다
- 혹시 세부 구현을 참조하셔야 된다면 BaseActivity, BaseViewModel, ShareActivity, WebActivity를 참고하시면 됩니다

### 체크해야 할 부분
- 참고로, ShareActivity에서는 로그인이 되어 있는 시점에서만 (BottomSheet를 표시할 떄) 강제업데이트 여부를 확인합니다. 따라서 비로그인 유저의 경우 ShareActivity로 진입하더라도 바로 SplashWithSignActivity로 진입하게 되며, 해당 화면에서 강제업데이트를 확인해주셔야 합니다.
- 처음에 `SplashWithSignActivity`의 onResume에 강제업데이트 dialog를 띄우려고 시도했으나, onCreate부분에서 MainActivity로 이동하는 로직 때문에 Dialog가 일시적으로 노출 된 후 MainActivity로 넘어가지는 원치않는 상황이 발생했습니다🥲